### PR TITLE
Add hypervisor (ARM64 bare-metal Type-1 in Rust)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ The goal is to collect all kinds of different open source OSs so people can stud
 * [gopher-os](https://github.com/gopher-os/gopher-os) - A proof of concept OS kernel written in Go
 * [hhuOS](https://github.com/hhuOS/hhuOS) - hhuOS is a small operating system written in C++ and Assembler for the x86-architecture. The main purpose of this project is to show how different aspects of operating systems theory can be implemented and linked together. The system is not aimed to be a full-featured operating system for daily use.
 * [hydrogen](https://github.com/mszoek/hydrogen) - toy OS. 64-bit, preemptive multitasking kernel supporting EFI, PCIe, SATA, framebuffer graphics mode, HFS+.
+* [hypervisor](https://github.com/willamhou/hypervisor) - ARM64 bare-metal Type-1 hypervisor in Rust (no_std). Runs at EL2, boots Linux with 4 vCPUs, virtio-blk/net, FF-A v1.1, S-EL2 SPMC, and pKVM integration. QEMU virt target.
 * [lyre](https://github.com/lyre-os/lyre) - x86 kernel and distribution powered by mlibc, GNU userland tools, and other common *nix software.
 * [managarm](https://github.com/managarm/managarm) - Pragmatic microkernel-based OS with fully asynchronous I/O
 * [menix](https://github.com/menix-os/menix) - A minimal and expandable Unix-like operating system.


### PR DESCRIPTION
Adds [hypervisor](https://github.com/willamhou/hypervisor) to the Open Source Operating Systems list.

**What it is**: ARM64 bare-metal Type-1 hypervisor written in Rust (`no_std`) with ARM64 assembly. Runs at EL2 on QEMU virt machine.

**Why it belongs here**: Fills a gap — the list has x86 hypervisors (orange_slice) and security-focused hypervisor OSes (Qubes OS, L4re), but no ARM64 bare-metal hypervisor. This project:

- Boots Linux 6.12.12 to BusyBox shell with 4 vCPUs, virtio-blk storage, and virtio-net
- Implements FF-A v1.1 (Firmware Framework for Arm) with S-EL2 SPMC
- Integrates with pKVM (Android's protected KVM) at NS-EL2
- 457 test assertions across 34 test suites
- MIT licensed
- Targets QEMU `virt` machine (no hardware required to try it)